### PR TITLE
fix(sign): remove public.pem in sign.js

### DIFF
--- a/src/lib/sign.js
+++ b/src/lib/sign.js
@@ -7,12 +7,8 @@ import home from 'user-home'
 
 function doSign (file, cb) {
   const privateKeyFile = path.join(home, '.apfe/rsa-key/private.pem')
-  const publicKeyFile = path.join(home, '.apfe/rsa-key/public.pem')
   console.log(`using the private.pem: ${privateKeyFile}`)
-  console.log(`using the public.pem: ${publicKeyFile}`)
   const privateKey = fs.readFileSync(privateKeyFile).toString()
-  const publicKey = fs.readFileSync(publicKeyFile).toString()
-  console.log(`\n${publicKey}\n`)
   const f = fs.ReadStream(file)
 
   const sign = crypto.createSign('RSA-SHA1')


### PR DESCRIPTION
Public key is not required for signature.