### PR TITLE
feat: Supports custom offline-package filename

### DIFF
--- a/src/bin/apfe-pack-pack.js
+++ b/src/bin/apfe-pack-pack.js
@@ -297,9 +297,9 @@ function gulpPkg (options, subapp, cb) {
   // Custom offline-package filename
   if (subapp.filename) {
     amrFilename = subapp.filename
-      .replace('{id}', subapp.id)
-      .replace('{version}', subapp.version)
-      .replace('{random}', Math.random().toString(36).substr(2, 6))
+      .replace('[id]', subapp.id)
+      .replace('[version]', subapp.version)
+      .replace('[random]', Math.random().toString(36).substr(2, 6))
   }
 
   amrFilename += '.amr'

--- a/src/bin/apfe-pack-pack.js
+++ b/src/bin/apfe-pack-pack.js
@@ -292,10 +292,20 @@ function signTar (distPath, files, cb) {
  * @param {Function} cb callback
  */
 function gulpPkg (options, subapp, cb) {
-  const amrFilename = `${subapp.id}_${subapp.version}.amr`
+  let amrFilename = `${subapp.id}_${subapp.version}`
+
+  // Custom offline-package filename
+  if (subapp.filename) {
+    amrFilename = subapp.filename
+      .replace('{id}', subapp.id)
+      .replace('{version}', subapp.version)
+      .replace('{random}', Math.random().toString(36).substr(2, 6))
+  }
+
+  amrFilename += '.amr'
 
   const packageDir = PACKAGE_DIR + '/' + subapp.version
-  const amrPath = path.join(ROOT_PATH, packageDir + '/' + amrFilename)
+  const amrPath = path.join(ROOT_PATH, packageDir, amrFilename)
   const srcPath = TEMP_DIR + '/**/*'
 
   gulp.task('zip', () => {


### PR DESCRIPTION
配置参考：https://github.com/ant-ife/vue-biz-app-template/pull/7/files#diff-ebf2741126a75bcd0ccbf8df09b0f0fd

支持三种占位符：
- `[id]`: pkg.subapp.id
- `[version]`: pkg.version
- `[random]`: [a-z0-9]{6}